### PR TITLE
Menutimer CSS fix

### DIFF
--- a/app/modules/styles-injection.js
+++ b/app/modules/styles-injection.js
@@ -64,7 +64,7 @@ const menuTimerStyles = `
 	top: 20px;
 	width: 221px;
 	height: 89px;
-	padding: 0;
+	padding: 20px;
 	margin:0;
 	border-radius: 0;
 	background-color: transparent;


### PR DESCRIPTION
I hope I didn't fail this time, anyways fixes Menutimer CSS so the gamemode isn't on top of the timer or reverse don't remember